### PR TITLE
Use C++17's filesystem header if we can

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,12 +54,19 @@ find_package(SDL2_image REQUIRED)
 include_directories(${SDL2_INCLUDE_DIRS} ${SDL2_IMAGE_INCLUDE_DIRS})
 
 # =========================================================
-# Boost
+# Filesystem (stdlib or Boost)
 
-set(Boost_USE_STATIC_LIBS ON)
-set(Boost_USE_MULTITHREADED ON)
-set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.40 COMPONENTS filesystem REQUIRED)
+# Aim for C++17's filesystem first, fallback on boost
+include(CheckCXXSymbolExists)
+check_cxx_symbol_exists(std::filesystem::path::preferred_separator "filesystem" USE_CXX17_FILESYSTEM)
+add_compile_definitions(USE_CXX17_FILESYSTEM=${USE_CXX17_FILESYSTEM})
+
+if (NOT USE_CXX17_FILESYSTEM)
+    set(Boost_USE_STATIC_LIBS ON)
+    set(Boost_USE_MULTITHREADED ON)
+    set(Boost_USE_STATIC_RUNTIME OFF)
+    find_package(Boost 1.40 COMPONENTS filesystem REQUIRED)
+endif()
 
 # =========================================================
 # STB
@@ -339,12 +346,14 @@ target_link_libraries(delta-core PUBLIC
     # Vulkan
     ${VULKAN_LIBS}/vulkan-1.lib
 
-    # Boost
-    Boost::filesystem
-
     winmm
     OpenGL32
 )
+
+# Boost
+if (NOT USE_CXX17_FILESYSTEM)
+    target_link_libraries(delta-core PUBLIC Boost::filesystem)
+endif()
 
 add_subdirectory(physics)
 add_subdirectory(engines)

--- a/engines/basic/include/path.h
+++ b/engines/basic/include/path.h
@@ -3,16 +3,26 @@
 
 #include <string>
 
+#if USE_CXX17_FILESYSTEM
+#include <filesystem>
+#else // USE_CXX17_FILESYSTEM
 namespace boost {
     namespace filesystem {
         class path;
     } /* namespace filesystem */
 } /* namespace boost */
+#endif // USE_CXX17_FILESYSTEM
 
 namespace dbasic {
 
+#if USE_CXX17_FILESYSTEM
+    namespace filesystem = std::filesystem;
+#else // USE_CXX17_FILESYSTEM
+    namespace filesystem = boost::filesystem;
+#endif // USE_CXX17_FILESYSTEM
+
     class Path {
-    protected: Path(const boost::filesystem::path &path);
+    protected: Path(const filesystem::path &path);
     public:
         Path(const std::string &path);
         Path(const char *path);
@@ -39,10 +49,10 @@ namespace dbasic {
         bool Exists() const;
 
     protected:
-        boost::filesystem::path *m_path;
+        filesystem::path *m_path;
 
     protected:
-        const boost::filesystem::path &GetBoostPath() const { return *m_path; }
+        const filesystem::path &GetPath() const { return *m_path; }
     };
 
 } /* namespace dbasic */

--- a/engines/basic/src/path.cpp
+++ b/engines/basic/src/path.cpp
@@ -1,6 +1,8 @@
 #include "../include/path.h"
 
+#if !USE_CXX17_FILESYSTEM
 #include <boost/filesystem.hpp>
+#endif // USE_CXX17_FILESYSTEM
 
 dbasic::Path::Path(const std::string &path) {
     m_path = nullptr;
@@ -13,16 +15,16 @@ dbasic::Path::Path(const char *path) {
 }
 
 dbasic::Path::Path(const Path &path) {
-    m_path = new boost::filesystem::path;
-    *m_path = path.GetBoostPath();
+    m_path = new filesystem::path;
+    *m_path = path.GetPath();
 }
 
 dbasic::Path::Path() {
     m_path = nullptr;
 }
 
-dbasic::Path::Path(const boost::filesystem::path &path) {
-    m_path = new boost::filesystem::path;
+dbasic::Path::Path(const filesystem::path &path) {
+    m_path = new filesystem::path;
     *m_path = path;
 }
 
@@ -37,27 +39,27 @@ std::string dbasic::Path::ToString() const {
 void dbasic::Path::SetPath(const std::string &path) {
     if (m_path != nullptr) delete m_path;
 
-    m_path = new boost::filesystem::path(path);
+    m_path = new filesystem::path(path);
 }
 
 bool dbasic::Path::operator==(const Path &path) const {
-    return boost::filesystem::equivalent(this->GetBoostPath(), path.GetBoostPath());
+    return filesystem::equivalent(this->GetPath(), path.GetPath());
 }
 
 dbasic::Path dbasic::Path::Append(const Path &path) const {
-    return Path(GetBoostPath() / path.GetBoostPath());
+    return Path(GetPath() / path.GetPath());
 }
 
 void dbasic::Path::GetParentPath(Path *path) const {
-    path->m_path = new boost::filesystem::path;
+    path->m_path = new filesystem::path;
     *path->m_path = m_path->parent_path();
 }
 
 const dbasic::Path &dbasic::Path::operator=(const Path &b) {
     if (m_path != nullptr) delete m_path;
 
-    m_path = new boost::filesystem::path;
-    *m_path = b.GetBoostPath();
+    m_path = new filesystem::path;
+    *m_path = b.GetPath();
 
     return *this;
 }
@@ -71,7 +73,7 @@ std::string dbasic::Path::GetStem() const {
 }
 
 dbasic::Path dbasic::Path::GetAbsolute() const {
-    return boost::filesystem::absolute(*m_path);
+    return filesystem::absolute(*m_path);
 }
 
 bool dbasic::Path::IsAbsolute() const {
@@ -79,5 +81,5 @@ bool dbasic::Path::IsAbsolute() const {
 }
 
 bool dbasic::Path::Exists() const {
-    return boost::filesystem::exists(*m_path);
+    return filesystem::exists(*m_path);
 }


### PR DESCRIPTION
This avoids having to find and build boost which is always a nice thing to skip. Basically a copy of ange-yaghi/piranha/pull/64.