### PR TITLE
Move some function to iso compliant c++

### DIFF
--- a/include/yds_allocator.h
+++ b/include/yds_allocator.h
@@ -1,27 +1,27 @@
 #ifndef YDS_ALLOCATOR_H
 #define YDS_ALLOCATOR_H
 
-#include <malloc.h>
+#include <cstdlib>
+#include <type_traits>
 
 class ysAllocator {
 public:
-    template <int Alignment>
+    template <int Alignment, typename std::enable_if<Alignment >= 2, int*>::type = nullptr>
     static void *BlockAllocate(int size) {
-        return ::_aligned_malloc(size, Alignment);
+        return aligned_alloc(Alignment, size);
     }
 
-    template <>
-    static void *BlockAllocate<1>(int size) {
-        return ::malloc(size);
+    template <int Alignment, typename std::enable_if<Alignment == 1, int*>::type = nullptr>
+    static void *BlockAllocate(int size) {
+        return malloc(size);
     }
 
-    static void BlockFree(void *block, int alignment) {
-        if (alignment != 1) {
-            ::_aligned_free(block);
-        }
-        else {
-            ::free(block);
-        }
+    static void BlockFree(void *block, int) {
+        free(block);
+    }
+    
+    static void BlockFree(void *block) {
+        free(block);
     }
 
     template <typename T_Create, int Alignment>

--- a/include/yds_audio_device.h
+++ b/include/yds_audio_device.h
@@ -1,6 +1,8 @@
 #ifndef YDS_AUDIO_DEVICE_H
 #define YDS_AUDIO_DEVICE_H
 
+#define __STDC_WANT_LIB_EXT1__ 1
+
 #include "yds_audio_system_object.h"
 #include "yds_audio_parameters.h"
 
@@ -21,7 +23,7 @@ public:
     ~ysAudioDevice();
 
     bool IsConnected() const { return m_connected; }
-    void SetDeviceName(const char *newName) { strcpy_s(m_deviceName, MaxDeviceNameLength, newName); }
+    void SetDeviceName(const char *newName) { strncpy(m_deviceName, newName, MaxDeviceNameLength); }
 
     virtual ysAudioBuffer *CreateBuffer(const ysAudioParameters *parameters, SampleOffset size) = 0;
 

--- a/include/yds_dynamic_array.h
+++ b/include/yds_dynamic_array.h
@@ -4,7 +4,7 @@
 #include "yds_error_codes.h"
 #include "yds_allocator.h"
 
-#include <memory>
+#include <cstring>
 
 class ysDynamicArrayElement {
 public:

--- a/include/yds_math.h
+++ b/include/yds_math.h
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 
+
 // Extra Definitions
 
 #define _mm_replicate_x_ps(v) \
@@ -118,7 +119,19 @@ struct ysMatrix33 {
     };
 };
 
-#define YS_MATH_CONST extern const __declspec(selectany)
+
+#if defined(_MSC_VER)
+    //  Microsoft 
+    #define EXPORT __declspec(selectany)
+#elif defined(__GNUC__)
+    //  GCC
+    #define EXPORT __attribute__((visibility("default")))
+#else
+    // Unknown system. Do nothing
+    #define EXPORT
+    #pragma warning Unknown dynamic linking system
+#endif
+#define YS_MATH_CONST extern const EXPORT
 
 namespace ysMath {
 

--- a/include/yds_math.h
+++ b/include/yds_math.h
@@ -133,6 +133,17 @@ struct ysMatrix33 {
 #endif
 #define YS_MATH_CONST extern const EXPORT
 
+#if defined(_MSC_VER)
+    //  Microsoft 
+    #define FORCE_INLINE __forceinline
+#elif defined(__GNUC__)
+    //  GCC
+    #define FORCE_INLINE __attribute__((always_inline))
+#else
+    // Unknown system. Use standard inline
+    #define FORCE_INLINE inline
+#endif
+
 namespace ysMath {
 
     namespace Constants {
@@ -198,7 +209,7 @@ namespace ysMath {
     int UniformRandomInt(int range);
 
     // Vector/General Quaternion
-    __forceinline ysGeneric LoadScalar(float s) {
+    FORCE_INLINE ysGeneric LoadScalar(float s) {
         return _mm_set_ps(s, s, s, s);
     }
 
@@ -213,23 +224,23 @@ namespace ysMath {
     ysVector4 GetVector4(const ysVector &v);
     ysVector3 GetVector3(const ysVector &v);
     ysVector2 GetVector2(const ysVector &v);
-    __forceinline float GetScalar(const ysVector &v) {
+    FORCE_INLINE float GetScalar(const ysVector &v) {
         return v.m128_f32[0];
     }
 
-    __forceinline float GetX(const ysVector &v) {
+    FORCE_INLINE float GetX(const ysVector &v) {
         return v.m128_f32[0];
     }
 
-    __forceinline float GetY(const ysVector &v) {
+    FORCE_INLINE float GetY(const ysVector &v) {
         return v.m128_f32[1];
     }
 
-    __forceinline float GetZ(const ysVector &v) {
+    FORCE_INLINE float GetZ(const ysVector &v) {
         return v.m128_f32[2];
     }
 
-    __forceinline float GetW(const ysVector &v) {
+    FORCE_INLINE float GetW(const ysVector &v) {
         return v.m128_f32[3];
     }
 
@@ -238,27 +249,27 @@ namespace ysMath {
     float GetQuatZ(const ysQuaternion &v);
     float GetQuatW(const ysQuaternion &v);
 
-    __forceinline ysGeneric Add(const ysGeneric &v1, const ysGeneric &v2) {
+    FORCE_INLINE ysGeneric Add(const ysGeneric &v1, const ysGeneric &v2) {
         return _mm_add_ps(v1, v2);
     }
 
-    __forceinline ysGeneric Sub(const ysGeneric &v1, const ysGeneric &v2) {
+    FORCE_INLINE ysGeneric Sub(const ysGeneric &v1, const ysGeneric &v2) {
         return _mm_sub_ps(v1, v2);
     }
 
-    __forceinline ysGeneric Mul(const ysGeneric &v1, const ysGeneric &v2) {
+    FORCE_INLINE ysGeneric Mul(const ysGeneric &v1, const ysGeneric &v2) {
         return _mm_mul_ps(v1, v2);
     }
 
-    __forceinline ysGeneric Div(const ysGeneric &v1, const ysGeneric &v2) {
+    FORCE_INLINE ysGeneric Div(const ysGeneric &v1, const ysGeneric &v2) {
         return _mm_div_ps(v1, v2);
     }
 
-    __forceinline ysGeneric Sqrt(const ysGeneric &v) {
+    FORCE_INLINE ysGeneric Sqrt(const ysGeneric &v) {
         return _mm_sqrt_ps(v);
     }
 
-    __forceinline ysVector Dot(const ysVector &v1, const ysVector &v2) {
+    FORCE_INLINE ysVector Dot(const ysVector &v1, const ysVector &v2) {
         ysVector t0 = _mm_mul_ps(v1, v2);
         ysVector t1 = _mm_shuffle_ps(t0, t0, _MM_SHUFFLE(1, 0, 3, 2));
         ysVector t2 = _mm_add_ps(t0, t1);
@@ -270,23 +281,23 @@ namespace ysMath {
     ysVector Dot3(const ysVector &v1, const ysVector &v2);
     ysVector Cross(const ysVector &v1, const ysVector &v2);
 
-    __forceinline ysVector MagnitudeSquared3(const ysVector &v) {
+    FORCE_INLINE ysVector MagnitudeSquared3(const ysVector &v) {
         ysVector selfDot = ysMath::Dot3(v, v);
 
         return selfDot;
     }
 
-    __forceinline ysVector Magnitude(const ysVector &v) {
+    FORCE_INLINE ysVector Magnitude(const ysVector &v) {
         ysVector selfDot = ysMath::Dot(v, v);
 
         return _mm_sqrt_ps(selfDot);
     }
 
-    __forceinline ysVector Normalize(const ysVector &v) {
+    FORCE_INLINE ysVector Normalize(const ysVector &v) {
         return ysMath::Div(v, ysMath::Magnitude(v));
     }
 
-    __forceinline ysVector Negate(const ysVector &v) {
+    FORCE_INLINE ysVector Negate(const ysVector &v) {
         return ysMath::Mul(v, ysMath::Constants::Negate);
     }
 

--- a/include/yds_math.h
+++ b/include/yds_math.h
@@ -225,23 +225,28 @@ namespace ysMath {
     ysVector3 GetVector3(const ysVector &v);
     ysVector2 GetVector2(const ysVector &v);
     FORCE_INLINE float GetScalar(const ysVector &v) {
-        return v.m128_f32[0];
+        ysVector V = _mm_shuffle_ps(v, v, _MM_SHUFFLE(0, 0, 0, 0));
+        return _mm_cvtss_f32(V);
     }
 
     FORCE_INLINE float GetX(const ysVector &v) {
-        return v.m128_f32[0];
+        ysVector V = _mm_shuffle_ps(v, v, _MM_SHUFFLE(0, 0, 0, 0));
+        return _mm_cvtss_f32(V);
     }
 
     FORCE_INLINE float GetY(const ysVector &v) {
-        return v.m128_f32[1];
+        ysVector V = _mm_shuffle_ps(v, v, _MM_SHUFFLE(1, 1, 1, 1));
+        return _mm_cvtss_f32(V);
     }
 
     FORCE_INLINE float GetZ(const ysVector &v) {
-        return v.m128_f32[2];
+        ysVector V = _mm_shuffle_ps(v, v, _MM_SHUFFLE(2, 2, 2, 2));
+        return _mm_cvtss_f32(V);
     }
 
     FORCE_INLINE float GetW(const ysVector &v) {
-        return v.m128_f32[3];
+        ysVector V = _mm_shuffle_ps(v, v, _MM_SHUFFLE(3, 3, 3, 3));
+        return _mm_cvtss_f32(V);
     }
 
     float GetQuatX(const ysQuaternion &v);

--- a/src/yds_audio_streaming.cpp
+++ b/src/yds_audio_streaming.cpp
@@ -97,7 +97,7 @@ ysError ysStreamingAudio::InitializeBuffer() {
         m_fileOffset += m_file->GetBufferSize();
     }
 
-    m_source->UnlockBufferSegments(audioBuffer, audioBufferSize, NULL, NULL);
+    m_source->UnlockBufferSegments(audioBuffer, audioBufferSize, nullptr, 0);
 
     m_currentWriteSubdivision = 0;
     m_currentReadSubdivision = 0;


### PR DESCRIPTION
I took some time to replace some of the MSVC specific attributes and features with iso / standard c++ ones.
Everything _should_ work and behave the same however I am unable to compile any further than now due to the use of platform specific libraries. It would be much appreciated if someone could test the changes.

I see moving to iso c++ a good change for any project and I hope that this might bring this project close to cross-platform compatibility.